### PR TITLE
Add hw3 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,32 @@
 4. В описании подов после развертывания видно readinessProbe, при нарушении синтаксиса описания пробы и, например, попытке развертывания из образа с другим тегом, развертывание остановится на попытке запуска первого пода, которое не будет завершаться успешно. Проверить можно командой kubectl rollout status deployment/frontend, выполнить откат командой kubectl rollout undo deployment/frontend.
 5. Выполнив запуск, можно увидеть, что запущено по одному поду на каждой ноде, при пробросе порта kubectl port-forward <имя любого pod в DaemonSet> 9100:9100 метрики будут в localhost:9100/metrics.
 
+
+# Выполнено ДЗ № 3 (networks)
+
+- Основное ДЗ
+- Задание со * (частично)
+
+## В процессе сделано:
+1. Добавлен корректный web-pod.yaml с пробами. Вопрос почему констуркция в пробе с проверкой командой "ps aux | grep my_web_server_process" не имеет смысла - т.к. всегда будет положительный ответ из-за наличия самого процесса grep в результате.
+2. Добавлен деплоймент web-deploy.yaml с тремя репликами и пробами.
+3. Добавлен web-svc-cip.yaml для создания Service типа ClusterIP
+4. Настроен IPVS, установлен MetalLB по методичке и с помощью манифеста metallb-config.yaml, создан Service типа LoadBalancer через web-svc-lb.yaml, добавлен маршрут в ОС.
+5. Создан Ingress через nginx-lb.yaml и с использованием MetalLb, приложение web подключено к Ingress через web-svc-headless.yaml, создано правило через web-ingress.yaml.
+6. Попробовал сделать Ingress для Dashboard из официального манифеста плюс dashboard.yaml
+
+## Как запустить проект:
+1. Выполняется kubectl apply -f web-pod.yaml
+2. Выполняется kubectl apply -f web-deploy.yaml
+3. Выполняется kubectl apply -f web-svc-cip.yaml
+4. IPVS по методичке, MetalLB аналогчино, далее запуск через kubectl apply -f metallb-config.yaml, kubectl apply -f web-svc-lb.yaml
+5. Применяются манифесты nginx-lb.yaml, web-svc-headless.yaml, web-ingress.yaml
+6. После настройки Dashboard применить dashboard.yaml
+
+## Как проверить работоспособность:
+1. Корректный статус пода после запуска.
+2. Корректный статус запуска деплоймента и подов.
+3. Появляется Service web-svc-cip с Cluster-IP.
+4. В kube-ipvs0 появляется ip-адрес, после установки MetalLB корректные статусы всех объектов, после применения web-svc-lb.yaml и добавления маршрута, страница отвечает через EXTERNAL-IP - curl http://172.17.255.1.
+5. Service ingress-nginx получил EXTERNAL-IP, приложения отвечает через curl http://172.17.255.2/index.html.
+6. Вроде бы отвечает страница к приложению через /dashboard - curl http://172.17.255.2/dashboard.

--- a/kubernetes-networks/dashboard/dashboard.yaml
+++ b/kubernetes-networks/dashboard/dashboard.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /dashboard
+            pathType: Prefix
+            backend:
+              service:
+                name: kubernetes-dashboard-web
+                port:
+                  name: web

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: first-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.17.255.1-172.17.255.255

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: aasolovey/web:1.0
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: "/index.html"
+            port: 8000
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      initContainers:
+      - name: init-web
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web-svc
+                port:
+                  number: 8000

--- a/kubernetes-networks/web-pod.yaml
+++ b/kubernetes-networks/web-pod.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: aasolovey/web:1.0
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: "/index.html"
+            port: 8000
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      initContainers:
+      - name: init-web
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ № 3 (networks)

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
1. Добавлен корректный web-pod.yaml с пробами. Вопрос почему констуркция в пробе с проверкой командой "ps aux | grep my_web_server_process" не имеет смысла - т.к. всегда будет положительный ответ из-за наличия самого процесса grep в результате.
2. Добавлен деплоймент web-deploy.yaml с тремя репликами и пробами.
3. Добавлен web-svc-cip.yaml для создания Service типа ClusterIP
4. Настроен IPVS, установлен MetalLB по методичке и с помощью манифеста metallb-config.yaml, создан Service типа LoadBalancer через web-svc-lb.yaml, добавлен маршрут в ОС.
5. Создан Ingress через nginx-lb.yaml и с использованием MetalLb, приложение web подключено к Ingress через web-svc-headless.yaml, создано правило через web-ingress.yaml.
6. Попробовал сделать Ingress для Dashboard из официального манифеста плюс dashboard.yaml

## Как запустить проект:
1. Выполняется kubectl apply -f web-pod.yaml
2. Выполняется kubectl apply -f web-deploy.yaml
3. Выполняется kubectl apply -f web-svc-cip.yaml
4. IPVS по методичке, MetalLB аналогчино, далее запуск через kubectl apply -f metallb-config.yaml, kubectl apply -f web-svc-lb.yaml
5. Применяются манифесты nginx-lb.yaml, web-svc-headless.yaml, web-ingress.yaml
6. После настройки Dashboard применить dashboard.yaml

## Как проверить работоспособность:
1. Корректный статус пода после запуска.
2. Корректный статус запуска деплоймента и подов.
3. Появляется Service web-svc-cip с Cluster-IP.
4. В kube-ipvs0 появляется ip-адрес, после установки MetalLB корректные статусы всех объектов, после применения web-svc-lb.yaml и добавления маршрута, страница отвечает через EXTERNAL-IP - curl http://172.17.255.1.
5. Service ingress-nginx получил EXTERNAL-IP, приложения отвечает через curl http://172.17.255.2/index.html.
6. Вроде бы отвечает страница к приложению через /dashboard - curl http://172.17.255.2/dashboard.

## PR checklist:
 - [x] Выставлен label с темой домашнего задания